### PR TITLE
feat(admin): implement announcements management page with filtering and details view

### DIFF
--- a/app/components/announcement/detail.vue
+++ b/app/components/announcement/detail.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { format } from "date-fns";
+
+defineProps<{
+  announcement: Announcement;
+}>();
+
+const emits = defineEmits<{ close: [boolean] }>();
+
+const dropdownItems = [[{
+  label: "Mark as unread",
+  icon: "i-lucide-circle-check-big",
+}, {
+  label: "Mark as important",
+  icon: "i-lucide-triangle-alert",
+}], [{
+  label: "Star thread",
+  icon: "i-lucide-star",
+}, {
+  label: "Mute thread",
+  icon: "i-lucide-circle-pause",
+}]];
+
+const toast = useToast();
+
+const reply = ref("");
+const loading = ref(false);
+
+function onSubmit() {
+  loading.value = true;
+
+  setTimeout(() => {
+    reply.value = "";
+
+    toast.add({
+      title: "Email sent",
+      description: "Your email has been sent successfully",
+      icon: "i-lucide-check-circle",
+      color: "success",
+    });
+
+    loading.value = false;
+  }, 1000);
+}
+</script>
+
+<template>
+  <UDashboardPanel id="announcement-detail">
+    <UDashboardNavbar
+      :title="announcement.title"
+      :toggle="false"
+    >
+      <template #leading>
+        <UButton
+          icon="i-lucide-x"
+          color="neutral"
+          variant="ghost"
+          class="-ms-1.5 cursor-pointer"
+          @click="emits('close', false)"
+        />
+      </template>
+
+      <template #right>
+        <UTooltip text="Archive">
+          <UButton
+            icon="i-lucide-inbox"
+            color="neutral"
+            variant="ghost"
+            class="cursor-pointer"
+          />
+        </UTooltip>
+
+        <UTooltip text="Reply">
+          <UButton
+            icon="i-lucide-reply"
+            color="neutral"
+            variant="ghost"
+            class="cursor-pointer"
+          />
+        </UTooltip>
+
+        <UDropdownMenu :items="dropdownItems">
+          <UButton
+            icon="i-lucide-ellipsis-vertical"
+            color="neutral"
+            variant="ghost"
+            class="cursor-pointer"
+          />
+        </UDropdownMenu>
+      </template>
+    </UDashboardNavbar>
+
+    <div class="flex sm:flex-row flex-col justify-between gap-1 p-4 sm:px-6 border-default border-b">
+      <div class="flex items-start gap-4 sm:my-1.5">
+        <UAvatar
+          :src="announcement.postedByAdmin.user.image!"
+          :text="generateInitials(announcement.postedByAdmin.user.name)"
+          :alt="announcement.postedByAdmin.user.name"
+          :style="`background-color: ${generateUserColor(announcement.postedByAdmin.user.id)}`"
+          :ui="{ fallback: 'text-white' }"
+          size="3xl"
+        />
+
+        <div class="min-w-0">
+          <p class="font-semibold text-highlighted">
+            {{ announcement.postedByAdmin.user.name }}
+          </p>
+
+          <p class="text-muted">
+            {{ announcement.postedByAdmin.user.email }}
+          </p>
+        </div>
+      </div>
+
+      <p class="sm:mt-2 max-sm:pl-16 text-muted text-sm">
+        {{ format(new Date(announcement.postedAt), 'dd MMM HH:mm') }}
+      </p>
+    </div>
+
+    <div class="flex-1 p-4 sm:p-6 overflow-y-auto">
+      <p class="whitespace-pre-wrap">
+        {{ announcement.content }}
+      </p>
+    </div>
+
+    <div class="px-4 sm:px-6 pb-4 shrink-0">
+      <UCard
+        variant="subtle"
+        class="mt-auto"
+        :ui="{ header: 'flex items-center gap-1.5 text-dimmed' }"
+      >
+        <template #header>
+          <UIcon
+            name="i-lucide-reply"
+            class="size-5"
+          />
+
+          <span class="text-sm truncate">
+            Reply to {{ announcement.postedByAdmin.user.name }} ({{ announcement.postedByAdmin.user.email }})
+          </span>
+        </template>
+
+        <form @submit.prevent="onSubmit">
+          <UTextarea
+            v-model="reply"
+            color="neutral"
+            variant="none"
+            required
+            autoresize
+            placeholder="Write your reply..."
+            :rows="4"
+            :disabled="loading"
+            class="w-full"
+            :ui="{ base: 'p-0 resize-none' }"
+          />
+
+          <div class="flex justify-between items-center">
+            <UTooltip text="Attach file">
+              <UButton
+                color="neutral"
+                variant="ghost"
+                icon="i-lucide-paperclip"
+                class="cursor-pointer"
+              />
+            </UTooltip>
+
+            <div class="flex justify-end items-center gap-2">
+              <UButton
+                color="neutral"
+                variant="ghost"
+                label="Save draft"
+              />
+
+              <UButton
+                type="submit"
+                color="neutral"
+                :loading="loading"
+                label="Send"
+                icon="i-lucide-send"
+                class="cursor-pointer"
+              />
+            </div>
+          </div>
+        </form>
+      </UCard>
+    </div>
+  </UDashboardPanel>
+</template>
+
+<style scoped>
+
+</style>

--- a/app/components/announcement/list.vue
+++ b/app/components/announcement/list.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { format, isToday } from "date-fns";
+
+const { announcements } = defineProps<{
+  announcements: Announcement[];
+}>();
+
+const announcementRefs = ref<Element[]>([]);
+
+const selectedAnnouncement = defineModel<Announcement | null>();
+
+watch(selectedAnnouncement, () => {
+  if (!selectedAnnouncement.value)
+    return;
+
+  const elementRef = announcementRefs.value[selectedAnnouncement.value.id];
+
+  if (elementRef) {
+    elementRef.scrollIntoView({ block: "nearest" });
+  }
+});
+
+defineShortcuts({
+  arrowdown: () => {
+    const index = announcements
+      .findIndex(announcement => announcement.id === selectedAnnouncement.value?.id);
+
+    if (index === -1) {
+      selectedAnnouncement.value = announcements[0];
+    }
+    else if (index < announcements.length - 1) {
+      selectedAnnouncement.value = announcements[index + 1];
+    }
+  },
+  arrowup: () => {
+    const index = announcements
+      .findIndex(announcement => announcement.id === selectedAnnouncement.value?.id);
+
+    if (index === -1) {
+      selectedAnnouncement.value = announcements[announcements.length - 1];
+    }
+    else if (index > 0) {
+      selectedAnnouncement.value = announcements[index - 1];
+    }
+  },
+});
+</script>
+
+<template>
+  <div class="divide-y divide-default overflow-y-auto">
+    <div
+      v-for="announcement in announcements"
+      :key="announcement.id"
+      :ref="el => { announcementRefs[announcement.id] = el as Element }"
+    >
+      <div
+        class="p-4 sm:px-6 border-l-2 text-sm transition-colors cursor-pointer"
+        :class="[
+          !announcement.isRead ? 'text-highlighted' : 'text-toned',
+          selectedAnnouncement && selectedAnnouncement.id === announcement.id
+            ? 'border-primary bg-primary/10'
+            : 'border-bg hover:border-primary hover:bg-primary/5',
+        ]"
+        @click="selectedAnnouncement = announcement"
+      >
+        <div
+          class="flex justify-between items-center"
+          :class="[!announcement.isRead && 'font-semibold']"
+        >
+          <div class="flex items-center gap-3">
+            {{ announcement.postedByAdmin.user.name }}
+
+            <UChip
+              v-if="!announcement.isRead"
+              color="error"
+            />
+          </div>
+
+          <span>{{ isToday(new Date(announcement.postedAt))
+            ? format(new Date(announcement.postedAt), 'HH:mm')
+            : format(new Date(announcement.postedAt), 'dd MMM') }}
+          </span>
+        </div>
+
+        <p
+          class="truncate"
+          :class="[!announcement.isRead && 'font-semibold']"
+        >
+          {{ announcement.title }}
+        </p>
+
+        <p class="text-dimmed line-clamp-1">
+          {{ announcement.content }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/app/composables/announcementData.ts
+++ b/app/composables/announcementData.ts
@@ -1,0 +1,37 @@
+export function useAnnouncementData() {
+  const { data, status, refresh } = useFetch<AnnouncementResponse>("/api/announcement/getAnnouncementData ", {
+    key: "admin-announcements",
+    lazy: true,
+    default: () => ({
+      announcements: [],
+    }),
+    getCachedData: (key, nuxtApp, ctx) => {
+      if (ctx.cause === "refresh:manual" || ctx.cause === "refresh:hook")
+        return undefined;
+      return nuxtApp.payload.data[key] ?? nuxtApp.static.data[key];
+    },
+  });
+
+  const selectedTab = ref("all");
+
+  const selectedAnnouncement = ref<Announcement | null>(null);
+
+  const announcements = computed<Announcement[]>(() => data.value?.announcements ?? []);
+
+  const filteredAnnouncements = computed<Announcement[]>(() => {
+    if (selectedTab.value === "unread") {
+      return announcements.value.filter(announcement => !announcement.isRead);
+    }
+    return announcements.value;
+  });
+
+  return {
+    data,
+    status,
+    announcements,
+    selectedTab,
+    filteredAnnouncements,
+    selectedAnnouncement,
+    refresh,
+  };
+}

--- a/app/pages/admin/announcements.vue
+++ b/app/pages/admin/announcements.vue
@@ -1,29 +1,141 @@
 <script setup lang="ts">
+import { breakpointsTailwind, useBreakpoints } from "@vueuse/core";
+
 definePageMeta({
   middleware: ["requires-auth", "admin"],
   layout: "admin-dashboard",
 });
 
 const title = ref("Announcements");
+
+const tabItems = [{
+  label: "All",
+  value: "all",
+}, {
+  label: "Unread",
+  value: "unread",
+}];
+
+const {
+  status,
+  selectedTab,
+  filteredAnnouncements,
+  selectedAnnouncement,
+} = useAnnouncementData();
+
+const isAnnouncementPanelOpen = computed({
+  get: () => !!selectedAnnouncement.value,
+  set: (val: boolean) => {
+    if (!val) {
+      selectedAnnouncement.value = null;
+    }
+  },
+});
+
+watch(filteredAnnouncements, () => {
+  if (!filteredAnnouncements.value.find(announcement => announcement.id === selectedAnnouncement.value?.id)) {
+    selectedAnnouncement.value = null;
+  }
+});
+
+const breakpoints = useBreakpoints(breakpointsTailwind);
+const isMobile = breakpoints.smaller("lg");
 </script>
 
 <template>
   <div class="flex flex-1">
-    <UDashboardPanel id="announcements">
+    <UDashboardPanel
+      id="announcements"
+      resizable
+      :default-size="25"
+      :min-size="20"
+      :max-size="30"
+      :ui="{
+        body: 'p-2 sm:p-0',
+      }"
+    >
       <template #header>
-        <DashboardNav :title />
+        <UDashboardNavbar :title>
+          <template #leading>
+            <UDashboardSidebarCollapse class="cursor-pointer" />
+          </template>
+
+          <template #trailing>
+            <UBadge
+              :label="filteredAnnouncements.length"
+              variant="subtle"
+            />
+          </template>
+
+          <template #right>
+            <UTabs
+              v-model="selectedTab"
+              :items="tabItems"
+              :content="false"
+              size="xs"
+              :ui="{
+                trigger: 'cursor-pointer',
+              }"
+            />
+          </template>
+        </UDashboardNavbar>
       </template>
 
       <template #body>
-        <div class="p-4">
-          <h1 class="mb-4 font-bold text-2xl">
-            Student Dashboard
-          </h1>
-          <!-- Analytics content goes here -->
-          <p>This is where you can display various dashboard data.</p>
-        </div>
+        <UEmpty
+          v-if="status === 'pending' || status === 'error' || filteredAnnouncements.length === 0"
+          variant="naked"
+          icon="i-lucide-bell"
+          title="No announcements"
+          description="You're all caught up. New announcements will appear here."
+          :actions="[
+            {
+              icon: 'i-lucide-loader',
+              label: 'Refresh',
+              color: 'neutral',
+              variant: 'subtle',
+            },
+          ]"
+        />
+
+        <AnnouncementList
+          v-else
+          v-model="selectedAnnouncement"
+          :announcements="filteredAnnouncements"
+        />
       </template>
     </UDashboardPanel>
+
+    <AnnouncementDetail
+      v-if="selectedAnnouncement"
+      :announcement="selectedAnnouncement"
+      @close="selectedAnnouncement = null"
+    />
+
+    <div
+      v-else
+      class="hidden lg:flex flex-1 justify-center items-center"
+    >
+      <UIcon
+        name="i-lucide-inbox"
+        class="size-32 text-dimmed"
+      />
+    </div>
+
+    <ClientOnly>
+      <USlideover
+        v-if="isMobile"
+        v-model:open="isAnnouncementPanelOpen"
+      >
+        <template #content>
+          <AnnouncementDetail
+            v-if="selectedAnnouncement"
+            :announcement="selectedAnnouncement"
+            @close="selectedAnnouncement = null"
+          />
+        </template>
+      </USlideover>
+    </ClientOnly>
   </div>
 </template>
 

--- a/server/api/announcement/getAnnouncementData.get.ts
+++ b/server/api/announcement/getAnnouncementData.get.ts
@@ -1,0 +1,35 @@
+import { announcementQueries, userQueries } from "~~/server/db/queries";
+
+export default defineEventHandler(async (event) => {
+  const { userId } = await adminSessionCheck(event);
+
+  try {
+    const { getAdminByUserId } = await userQueries();
+    const { getAllAnnouncementsForAdmin } = await announcementQueries();
+
+    const adminMakingRequest = await getAdminByUserId(
+      userId,
+      true,
+    );
+
+    if (!adminMakingRequest) {
+      throw createError({
+        statusCode: 403,
+        message: "Account for the admin making the request not found or is inactive.",
+      });
+    }
+
+    const announcements = await getAllAnnouncementsForAdmin(adminMakingRequest);
+
+    return {
+      announcements,
+    };
+  }
+  catch (error) {
+    if (error && typeof error === "object" && "statusCode" in error) {
+      throw error;
+    }
+
+    handleError(error, "Get Announcement Data", event);
+  }
+});

--- a/server/db/migrations/0010_late_ben_grimm.sql
+++ b/server/db/migrations/0010_late_ben_grimm.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "announcement" ALTER COLUMN "target_audience" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "announcement" ALTER COLUMN "target_audience" SET DEFAULT 'all'::text;--> statement-breakpoint
+DROP TYPE "public"."target_audience";--> statement-breakpoint
+CREATE TYPE "public"."target_audience" AS ENUM('all', 'students', 'admins', 'hostel', 'room', 'user');--> statement-breakpoint
+ALTER TABLE "announcement" ALTER COLUMN "target_audience" SET DEFAULT 'all'::"public"."target_audience";--> statement-breakpoint
+ALTER TABLE "announcement" ALTER COLUMN "target_audience" SET DATA TYPE "public"."target_audience" USING "target_audience"::"public"."target_audience";--> statement-breakpoint
+ALTER TABLE "announcement" ADD COLUMN "target_hostel_id" integer;--> statement-breakpoint
+ALTER TABLE "announcement" ADD COLUMN "target_room_id" integer;--> statement-breakpoint
+ALTER TABLE "announcement" ADD COLUMN "target_user_id" integer;--> statement-breakpoint
+ALTER TABLE "announcement" ADD CONSTRAINT "announcement_target_hostel_id_hostel_id_fk" FOREIGN KEY ("target_hostel_id") REFERENCES "public"."hostel"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "announcement" ADD CONSTRAINT "announcement_target_room_id_room_id_fk" FOREIGN KEY ("target_room_id") REFERENCES "public"."room"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "announcement" ADD CONSTRAINT "announcement_target_user_id_user_id_fk" FOREIGN KEY ("target_user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/server/db/migrations/meta/0010_snapshot.json
+++ b/server/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,2192 @@
+{
+  "id": "bad4f6c9-812d-4b8b-9414-fdf276db3562",
+  "prevId": "f531f2e2-4c8d-417f-9d22-5b88cbf9cecc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcement": {
+      "name": "announcement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "announcement_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "posted_by": {
+          "name": "posted_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "announcement_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "target_audience": {
+          "name": "target_audience",
+          "type": "target_audience",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "target_hostel_id": {
+          "name": "target_hostel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_room_id": {
+          "name": "target_room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcement_posted_by_admin_id_fk": {
+          "name": "announcement_posted_by_admin_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "admin",
+          "columnsFrom": [
+            "posted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "announcement_target_hostel_id_hostel_id_fk": {
+          "name": "announcement_target_hostel_id_hostel_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "hostel",
+          "columnsFrom": [
+            "target_hostel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "announcement_target_room_id_room_id_fk": {
+          "name": "announcement_target_room_id_room_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "room",
+          "columnsFrom": [
+            "target_room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "announcement_target_user_id_user_id_fk": {
+          "name": "announcement_target_user_id_user_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcement_reads": {
+      "name": "announcement_reads",
+      "schema": "",
+      "columns": {
+        "read_id": {
+          "name": "read_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "announcement_reads_read_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "announcement_id": {
+          "name": "announcement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_date": {
+          "name": "read_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcement_reads_announcement_id_announcement_id_fk": {
+          "name": "announcement_reads_announcement_id_announcement_id_fk",
+          "tableFrom": "announcement_reads",
+          "tableTo": "announcement",
+          "columnsFrom": [
+            "announcement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "announcement_reads_user_id_user_id_fk": {
+          "name": "announcement_reads_user_id_user_id_fk",
+          "tableFrom": "announcement_reads",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_announcement_student": {
+          "name": "unique_announcement_student",
+          "nullsNotDistinct": false,
+          "columns": [
+            "announcement_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing": {
+      "name": "billing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "billing_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocation_id": {
+          "name": "allocation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostel_id": {
+          "name": "hostel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_issued": {
+          "name": "date_issued",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "billing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpaid'"
+        },
+        "late_fee": {
+          "name": "late_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.00'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.00'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_student_id_student_id_fk": {
+          "name": "billing_student_id_student_id_fk",
+          "tableFrom": "billing",
+          "tableTo": "student",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "billing_allocation_id_allocation_id_fk": {
+          "name": "billing_allocation_id_allocation_id_fk",
+          "tableFrom": "billing",
+          "tableTo": "allocation",
+          "columnsFrom": [
+            "allocation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "billing_hostel_id_hostel_id_fk": {
+          "name": "billing_hostel_id_hostel_id_fk",
+          "tableFrom": "billing",
+          "tableTo": "hostel",
+          "columnsFrom": [
+            "hostel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_paid_amount": {
+          "name": "chk_paid_amount",
+          "value": "paid_amount >= 0 AND paid_amount <= amount"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "payment_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_id": {
+          "name": "billing_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "transaction_reference": {
+          "name": "transaction_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_student_id_student_id_fk": {
+          "name": "payment_student_id_student_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "student",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_billing_id_billing_id_fk": {
+          "name": "payment_billing_id_billing_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "billing",
+          "columnsFrom": [
+            "billing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payment_transactionReference_unique": {
+          "name": "payment_transactionReference_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "transaction_reference"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.complaint": {
+      "name": "complaint",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "complaint_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostel_id": {
+          "name": "hostel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "complaint_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "complaint_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "status": {
+          "name": "status",
+          "type": "complaint_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "complaint_student_id_student_id_fk": {
+          "name": "complaint_student_id_student_id_fk",
+          "tableFrom": "complaint",
+          "tableTo": "student",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "complaint_room_id_room_id_fk": {
+          "name": "complaint_room_id_room_id_fk",
+          "tableFrom": "complaint",
+          "tableTo": "room",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "complaint_hostel_id_hostel_id_fk": {
+          "name": "complaint_hostel_id_hostel_id_fk",
+          "tableFrom": "complaint",
+          "tableTo": "hostel",
+          "columnsFrom": [
+            "hostel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.complaint_response": {
+      "name": "complaint_response",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "complaint_response_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "complaint_id": {
+          "name": "complaint_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responder_id": {
+          "name": "responder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "complaint_action_taken",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_date": {
+          "name": "response_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "complaint_response_complaint_id_complaint_id_fk": {
+          "name": "complaint_response_complaint_id_complaint_id_fk",
+          "tableFrom": "complaint_response",
+          "tableTo": "complaint",
+          "columnsFrom": [
+            "complaint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "complaint_response_responder_id_user_id_fk": {
+          "name": "complaint_response_responder_id_user_id_fk",
+          "tableFrom": "complaint_response",
+          "tableTo": "user",
+          "columnsFrom": [
+            "responder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_request": {
+      "name": "maintenance_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maintenance_request_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostel_id": {
+          "name": "hostel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "maintenance_issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_date": {
+          "name": "request_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "maintenance_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "status": {
+          "name": "status",
+          "type": "maintenance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_date": {
+          "name": "resolution_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maintenance_request_student_id_student_id_fk": {
+          "name": "maintenance_request_student_id_student_id_fk",
+          "tableFrom": "maintenance_request",
+          "tableTo": "student",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "maintenance_request_room_id_room_id_fk": {
+          "name": "maintenance_request_room_id_room_id_fk",
+          "tableFrom": "maintenance_request",
+          "tableTo": "room",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "maintenance_request_hostel_id_hostel_id_fk": {
+          "name": "maintenance_request_hostel_id_hostel_id_fk",
+          "tableFrom": "maintenance_request",
+          "tableTo": "hostel",
+          "columnsFrom": [
+            "hostel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_response": {
+      "name": "maintenance_response",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maintenance_response_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maintenance_request_id": {
+          "name": "maintenance_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responder_id": {
+          "name": "responder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_text": {
+          "name": "response_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_date": {
+          "name": "response_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maintenance_response_maintenance_request_id_maintenance_request_id_fk": {
+          "name": "maintenance_response_maintenance_request_id_maintenance_request_id_fk",
+          "tableFrom": "maintenance_response",
+          "tableTo": "maintenance_request",
+          "columnsFrom": [
+            "maintenance_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "maintenance_response_responder_id_user_id_fk": {
+          "name": "maintenance_response_responder_id_user_id_fk",
+          "tableFrom": "maintenance_response",
+          "tableTo": "user",
+          "columnsFrom": [
+            "responder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_response_text": {
+          "name": "chk_response_text",
+          "value": "char_length(response_text) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.allocation": {
+      "name": "allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "allocation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocation_date": {
+          "name": "allocation_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "allocation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "allocation_student_id_student_id_fk": {
+          "name": "allocation_student_id_student_id_fk",
+          "tableFrom": "allocation",
+          "tableTo": "student",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "allocation_room_id_room_id_fk": {
+          "name": "allocation_room_id_room_id_fk",
+          "tableFrom": "allocation",
+          "tableTo": "room",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_active_allocation": {
+          "name": "unique_active_allocation",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_id",
+            "status"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chk_dates": {
+          "name": "chk_dates",
+          "value": "end_date IS NULL OR end_date >= allocation_date"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.hostel": {
+      "name": "hostel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "hostel_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_number": {
+          "name": "contact_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "hostel_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hostel_name_unique": {
+          "name": "hostel_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "hostel_email_unique": {
+          "name": "hostel_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.room": {
+      "name": "room",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "room_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "room_number": {
+          "name": "room_number",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostel_id": {
+          "name": "hostel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "floor": {
+          "name": "floor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_type": {
+          "name": "room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "features": {
+          "name": "features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "ARRAY[]::text[]"
+        },
+        "amount_per_year": {
+          "name": "amount_per_year",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "room_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vacant'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "room_hostel_id_hostel_id_fk": {
+          "name": "room_hostel_id_hostel_id_fk",
+          "tableFrom": "room",
+          "tableTo": "hostel",
+          "columnsFrom": [
+            "hostel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "room_roomNumber_unique": {
+          "name": "room_roomNumber_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "room_number"
+          ]
+        },
+        "unique_room_number": {
+          "name": "unique_room_number",
+          "nullsNotDistinct": false,
+          "columns": [
+            "room_number",
+            "hostel_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chk_capacity": {
+          "name": "chk_capacity",
+          "value": "capacity > 0"
+        },
+        "chk_occupancy": {
+          "name": "chk_occupancy",
+          "value": "current_occupancy >= 0 AND current_occupancy <= capacity"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.admin": {
+      "name": "admin",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "admin_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "access_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "hostel_id": {
+          "name": "hostel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "admin_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_user_id_user_id_fk": {
+          "name": "admin_user_id_user_id_fk",
+          "tableFrom": "admin",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_hostel_id_hostel_id_fk": {
+          "name": "admin_hostel_id_hostel_id_fk",
+          "tableFrom": "admin",
+          "tableTo": "hostel",
+          "columnsFrom": [
+            "hostel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_hostel_for_regular_support": {
+          "name": "chk_hostel_for_regular_support",
+          "value": "\n    (access_level IN ('regular', 'support') AND hostel_id IS NOT NULL)\n    OR (access_level = 'super' AND hostel_id IS NULL)\n  "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.login_attempts": {
+      "name": "login_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "login_attempts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "login_attempts_user_id_user_id_fk": {
+          "name": "login_attempts_user_id_user_id_fk",
+          "tableFrom": "login_attempts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student": {
+      "name": "student",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "student_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emergency_contact_phone_number": {
+          "name": "emergency_contact_phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "health_conditions": {
+          "name": "health_conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollment_date": {
+          "name": "enrollment_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residency_status": {
+          "name": "residency_status",
+          "type": "residency_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inactive'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_user_id_user_id_fk": {
+          "name": "student_user_id_user_id_fk",
+          "tableFrom": "student",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "roles",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'student'"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_token_expires_at": {
+          "name": "verification_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_token": {
+          "name": "reset_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_token_expires_at": {
+          "name": "reset_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.visitor": {
+      "name": "visitor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "visitor_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostel_id": {
+          "name": "hostel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_date": {
+          "name": "visit_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "visitor_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "visitor_student_id_student_id_fk": {
+          "name": "visitor_student_id_student_id_fk",
+          "tableFrom": "visitor",
+          "tableTo": "student",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "visitor_hostel_id_hostel_id_fk": {
+          "name": "visitor_hostel_id_hostel_id_fk",
+          "tableFrom": "visitor",
+          "tableTo": "hostel",
+          "columnsFrom": [
+            "hostel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "visitor_admin_id_admin_id_fk": {
+          "name": "visitor_admin_id_admin_id_fk",
+          "tableFrom": "visitor",
+          "tableTo": "admin",
+          "columnsFrom": [
+            "admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_visit_date": {
+          "name": "chk_visit_date",
+          "value": "\"visit_date\" >= CURRENT_DATE"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visitor_logs": {
+      "name": "visitor_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "visitor_logs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "visitor_log_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "visitor_logs_visitor_id_visitor_id_fk": {
+          "name": "visitor_logs_visitor_id_visitor_id_fk",
+          "tableFrom": "visitor_logs",
+          "tableTo": "visitor",
+          "columnsFrom": [
+            "visitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "visitor_logs_admin_id_admin_id_fk": {
+          "name": "visitor_logs_admin_id_admin_id_fk",
+          "tableFrom": "visitor_logs",
+          "tableTo": "admin",
+          "columnsFrom": [
+            "admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.announcement_priority": {
+      "name": "announcement_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "medium",
+        "high",
+        "emergency"
+      ]
+    },
+    "public.target_audience": {
+      "name": "target_audience",
+      "schema": "public",
+      "values": [
+        "all",
+        "students",
+        "admins",
+        "hostel",
+        "room",
+        "user"
+      ]
+    },
+    "public.billing_status": {
+      "name": "billing_status",
+      "schema": "public",
+      "values": [
+        "unpaid",
+        "fully paid",
+        "partially paid",
+        "overdue",
+        "cancelled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "card",
+        "mobile money",
+        "bank transfer",
+        "cash"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "completed",
+        "failed",
+        "pending",
+        "refunded"
+      ]
+    },
+    "public.complaint_action_taken": {
+      "name": "complaint_action_taken",
+      "schema": "public",
+      "values": [
+        "assigned",
+        "updated",
+        "resolved",
+        "rejected"
+      ]
+    },
+    "public.complaint_priority": {
+      "name": "complaint_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "medium",
+        "high",
+        "emergency"
+      ]
+    },
+    "public.complaint_status": {
+      "name": "complaint_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in-progress",
+        "resolved",
+        "rejected"
+      ]
+    },
+    "public.complaint_type": {
+      "name": "complaint_type",
+      "schema": "public",
+      "values": [
+        "room condition",
+        "staff behavior",
+        "amenities",
+        "noise",
+        "security",
+        "billing issue",
+        "other"
+      ]
+    },
+    "public.maintenance_issue_type": {
+      "name": "maintenance_issue_type",
+      "schema": "public",
+      "values": [
+        "plumbing",
+        "electrical",
+        "furniture",
+        "cleaning",
+        "appliance",
+        "structural",
+        "pest control",
+        "internet/Wi-Fi",
+        "other"
+      ]
+    },
+    "public.maintenance_priority": {
+      "name": "maintenance_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "medium",
+        "high",
+        "emergency"
+      ]
+    },
+    "public.maintenance_status": {
+      "name": "maintenance_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "assigned",
+        "in-progress",
+        "completed",
+        "rejected"
+      ]
+    },
+    "public.allocation_status": {
+      "name": "allocation_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "pending",
+        "cancelled"
+      ]
+    },
+    "public.hostel_status": {
+      "name": "hostel_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "under renovation"
+      ]
+    },
+    "public.room_status": {
+      "name": "room_status",
+      "schema": "public",
+      "values": [
+        "vacant",
+        "fully occupied",
+        "partially occupied",
+        "under maintenance",
+        "reserved"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "single",
+        "double",
+        "triple",
+        "quad"
+      ]
+    },
+    "public.access_level": {
+      "name": "access_level",
+      "schema": "public",
+      "values": [
+        "regular",
+        "super",
+        "support"
+      ]
+    },
+    "public.admin_status": {
+      "name": "admin_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.residency_status": {
+      "name": "residency_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "suspended",
+        "graduated",
+        "withdrawn"
+      ]
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "public",
+      "values": [
+        "student",
+        "admin"
+      ]
+    },
+    "public.visitor_log_action": {
+      "name": "visitor_log_action",
+      "schema": "public",
+      "values": [
+        "check_in",
+        "check_out"
+      ]
+    },
+    "public.visitor_status": {
+      "name": "visitor_status",
+      "schema": "public",
+      "values": [
+        "checked-in",
+        "checked-out",
+        "pending",
+        "cancelled",
+        "denied",
+        "approved"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1763914509023,
       "tag": "0009_careless_colleen_wing",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1764337110202,
+      "tag": "0010_late_ben_grimm",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/queries/announcement.ts
+++ b/server/db/queries/announcement.ts
@@ -1,0 +1,83 @@
+import { desc, eq } from "drizzle-orm";
+
+import { announcement } from "../schema";
+
+const announcementWithRelations = {
+  orderBy: desc(announcement.postedAt),
+  with: {
+    postedByAdmin: {
+      with: {
+        user: {
+          columns: {
+            id: true,
+            name: true,
+            email: true,
+            image: true,
+          },
+        },
+      },
+    },
+    targetHostel: true,
+    targetRoom: true,
+    targetUser: {
+      columns: {
+        id: true,
+        name: true,
+        email: true,
+        image: true,
+      },
+    },
+  },
+} as const;
+
+export async function announcementQueries() {
+  const { db } = useDB();
+
+  const createAnnouncement = async (data: AnnouncementInsert) => {
+    const [newAnnouncement] = await db
+      .insert(announcement)
+      .values(data)
+      .returning();
+    return newAnnouncement;
+  };
+
+  const getAllAnnouncementsForAdmin = async (admin: Admin) => {
+    if (admin.accessLevel === "super") {
+      return await db
+        .query
+        .announcement
+        .findMany(announcementWithRelations);
+    }
+
+    if (!admin.hostelId)
+      return [];
+
+    return await db
+      .query
+      .announcement
+      .findMany({
+        ...announcementWithRelations,
+        where: eq(announcement.postedBy, admin.id),
+      });
+  };
+
+  const getAnnouncementById = async (announcementId: number) => {
+    return await db
+      .query
+      .announcement
+      .findFirst({
+        ...announcementWithRelations,
+        where: eq(announcement.id, announcementId),
+      });
+  };
+
+  return {
+    createAnnouncement,
+    getAllAnnouncementsForAdmin,
+    getAnnouncementById,
+  };
+}
+
+type AnnouncementWithRelations = Awaited<ReturnType<Awaited<ReturnType<typeof announcementQueries>>["getAnnouncementById"]>>;
+
+export type AnnouncementType = NonNullable<AnnouncementWithRelations>;

--- a/server/db/queries/index.ts
+++ b/server/db/queries/index.ts
@@ -1,4 +1,4 @@
-// export * from "./announcement";
+export * from "./announcement";
 // export * from "./billing";
 export * from "./complaint";
 export * from "./maintenance";

--- a/server/db/schema/announcement.ts
+++ b/server/db/schema/announcement.ts
@@ -1,11 +1,24 @@
 import { relations } from "drizzle-orm";
 import { pgEnum, pgTable, unique } from "drizzle-orm/pg-core";
 
+import { hostel, room } from "./room";
 import { admin, user } from "./user";
 
-export const announcementPriorityEnum = pgEnum("announcement_priority", ["low", "medium", "high", "emergency"]);
+export const announcementPriorityEnum = pgEnum("announcement_priority", [
+  "low",
+  "medium",
+  "high",
+  "emergency",
+]);
 
-export const targetAudienceEnum = pgEnum("target_audience", ["all", "students", "admins", "specific"]);
+export const targetAudienceEnum = pgEnum("target_audience", [
+  "all",
+  "students",
+  "admins",
+  "hostel",
+  "room",
+  "user",
+]);
 
 export const announcement = pgTable("announcement", t => ({
   id: t.integer().primaryKey().generatedAlwaysAsIdentity(),
@@ -15,6 +28,9 @@ export const announcement = pgTable("announcement", t => ({
   postedAt: t.timestamp().defaultNow().notNull(),
   priority: announcementPriorityEnum().default("medium").notNull(),
   targetAudience: targetAudienceEnum().default("all").notNull(),
+  targetHostelId: t.integer().references(() => hostel.id, { onDelete: "cascade" }),
+  targetRoomId: t.integer().references(() => room.id, { onDelete: "cascade" }),
+  targetUserId: t.integer().references(() => user.id, { onDelete: "cascade" }),
   isRead: t.boolean().default(false).notNull(),
 }));
 
@@ -31,6 +47,18 @@ export const announcementRelations = relations(announcement, ({ one, many }) => 
   postedByAdmin: one(admin, {
     fields: [announcement.postedBy],
     references: [admin.id],
+  }),
+  targetHostel: one(hostel, {
+    fields: [announcement.targetHostelId],
+    references: [hostel.id],
+  }),
+  targetRoom: one(room, {
+    fields: [announcement.targetRoomId],
+    references: [room.id],
+  }),
+  targetUser: one(user, {
+    fields: [announcement.targetUserId],
+    references: [user.id],
   }),
   reads: many(announcementReads),
 }));

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -2,11 +2,12 @@ import type { DropdownMenuItem } from "@nuxt/ui";
 import type { Table } from "@tanstack/vue-table";
 import type { useFetch } from "#app";
 import type { User } from "#auth-utils";
+import type { AnnouncementType } from "~~/server/db/queries/announcement";
 import type { ComplaintType } from "~~/server/db/queries/complaint";
 import type { Maintenance } from "~~/server/db/queries/maintenance";
 import type { Room as RoomType } from "~~/server/db/queries/room";
 import type { Visitor } from "~~/server/db/queries/visitor";
-import type { allocation, complaintActionTakenEnum, complaintStatusEnum, loginAttempts, maintenanceStatusEnum, room, visitorLogs } from "~~/server/db/schema";
+import type { allocation, announcement, complaintActionTakenEnum, complaintStatusEnum, loginAttempts, maintenanceStatusEnum, room, visitorLogs } from "~~/server/db/schema";
 import type { randomUUID } from "node:crypto";
 import type { ComputedOptions, ConcreteComponent, MethodOptions, Ref, ShallowRef, ShallowUnwrapRef } from "vue";
 import type { RouteLocationRaw } from "vue-router";
@@ -249,3 +250,9 @@ export type ComplaintAction = MaintenanceAction;
 export type ComplaintStatusForm = Omit<ComplaintStatusResponseSchema, "complaintId">;
 export type ComplaintStatus = typeof complaintStatusEnum["enumValues"][number];
 export type ComplaintActionTaken = typeof complaintActionTakenEnum["enumValues"][number];
+
+export type AnnouncementInsert = typeof announcement.$inferInsert;
+export type Announcement = AnnouncementType;
+export type AnnouncementResponse = {
+  announcements: Announcement[];
+};

--- a/shared/utils/schema.ts
+++ b/shared/utils/schema.ts
@@ -281,6 +281,59 @@ const complaintStatusResponseSchema = z.object({
 
 export type ComplaintStatusResponseSchema = z.output<typeof complaintStatusResponseSchema>;
 
+export const announcementPrioritySchema = z.enum([
+  "low",
+  "medium",
+  "high",
+  "emergency",
+]);
+export const targetAudienceSchema = z.enum([
+  "all",
+  "students",
+  "admins",
+  "hostel",
+  "room",
+  "user",
+]);
+
+export const createAnnouncementSchema = z.object({
+  title: z.string()
+    .nonempty("Title is required")
+    .min(5, "Title must be at least 5 characters long")
+    .max(200, "Title cannot exceed 200 characters"),
+  priority: announcementPrioritySchema,
+  targetAudience: targetAudienceSchema,
+  targetHostelId: z.number().optional(),
+  targetRoomId: z.number().optional(),
+  targetUserId: z.number().optional(),
+}).superRefine((data, ctx) => {
+  if (data.targetAudience === "hostel" && !data.targetHostelId) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Target Hostel ID is required when target audience is 'hostel'",
+      path: ["targetHostelId"],
+    });
+  }
+
+  if (data.targetAudience === "room" && !data.targetRoomId) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Target Room ID is required when target audience is 'room'",
+      path: ["targetRoomId"],
+    });
+  }
+
+  if (data.targetAudience === "user" && !data.targetUserId) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Target User ID is required when target audience is 'user'",
+      path: ["targetUserId"],
+    });
+  }
+});
+
+export type CreateAnnouncementSchema = z.output<typeof createAnnouncementSchema>;
+
 export {
   addAdminSchema,
   approveDenySchema,


### PR DESCRIPTION
Add a comprehensive announcements page for admins, replacing the placeholder content. Includes tabbed filtering (All/Unread), resizable panel, announcement list and detail views, responsive design with mobile slideover, and integration with announcement data queries. Enable announcement database queries and add migration for schema support. This enhances admin capabilities for managing and viewing announcements.