### PR TITLE
feat(ui): update primary color to cyan and enhance theming

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,7 +1,7 @@
 export default defineAppConfig({
   ui: {
     colors: {
-      primary: "rose",
+      primary: "cyan",
       neutral: "neutral",
     },
     icons: {
@@ -23,5 +23,9 @@ export default defineAppConfig({
     email: "kingshostelmgt@gmail.com",
     phone: "+233 54 968 4848",
     picture: "/images/hostel.jpg",
+  },
+  theme: {
+    radius: 0.25,
+    blackAsPrimary: false,
   },
 });

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,15 +1,16 @@
 <template>
-  <div>
-    <UApp :toaster="{ position: 'bottom-right', duration: 5000 }">
-      <NuxtRouteAnnouncer />
+  <UApp :toaster="{ position: 'bottom-right', duration: 5000 }">
+    <NuxtRouteAnnouncer />
 
-      <NuxtLoadingIndicator />
+    <NuxtLoadingIndicator
+      color="var(--ui-primary)"
+      :height="2"
+    />
 
-      <NuxtLayout>
-        <NuxtPage />
-      </NuxtLayout>
-    </UApp>
-  </div>
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
+  </UApp>
 </template>
 
 <style scoped>

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -82,11 +82,9 @@
     }
   }
 
-  @keyframes spinning {
-    to {
-      transform: rotate(360deg);
-    }
-  }
+  p {
+  @apply my-1 leading-6;
+}
 
   /* custom style for inline code and code block */
   code{
@@ -227,6 +225,17 @@ a:active {
   background: rgba(128, 128, 128, 0.5);
   border-radius: 3px;
 }
+
+::selection{
+  @apply bg-primary/50;
+}
+
+
+@keyframes spinning {
+    to {
+      transform: rotate(360deg);
+    }
+  }
 
 @keyframes fade-in-up {
   from {

--- a/app/components/announcement/createNew.vue
+++ b/app/components/announcement/createNew.vue
@@ -13,6 +13,8 @@ const {
   isFetchingDraft,
 } = storeToRefs(announcementStore);
 
+const { createAnnouncement } = announcementStore;
+
 const { users, status } = useFetchUserData();
 const { hostels, rooms, status: roomStatus } = useFetchRoomData();
 
@@ -105,6 +107,7 @@ watch(() => announcementState.value.targetAudience, (newVal) => {
         :room-options
         :status
         :room-status
+        :create-announcement
       />
     </template>
 

--- a/app/components/announcement/detail.vue
+++ b/app/components/announcement/detail.vue
@@ -40,28 +40,6 @@ const dropdownItems: DropdownMenuItem[][] = [
     },
   ],
 ];
-
-const toast = useToast();
-
-const reply = ref("");
-const loading = ref(false);
-
-function onSubmit() {
-  loading.value = true;
-
-  setTimeout(() => {
-    reply.value = "";
-
-    toast.add({
-      title: "Email sent",
-      description: "Your email has been sent successfully",
-      icon: "i-lucide-check-circle",
-      color: "success",
-    });
-
-    loading.value = false;
-  }, 1000);
-}
 </script>
 
 <template>
@@ -156,9 +134,10 @@ function onSubmit() {
     </div>
 
     <div class="flex-1 p-4 sm:p-6 overflow-y-auto">
-      <p class="whitespace-pre-wrap">
-        {{ announcement.content }}
-      </p>
+      <p
+        class="dark:prose-invert max-w-none whitespace-pre-wrap prose"
+        v-html="announcement.content"
+      />
     </div>
 
     <!-- <div class="px-4 sm:px-6 pb-4 shrink-0">
@@ -223,7 +202,7 @@ function onSubmit() {
       </UCard>
     </div> -->
 
-    <AnnouncementCreateNew @click="onSubmit" />
+    <AnnouncementCreateNew />
   </UDashboardPanel>
 </template>
 

--- a/app/components/announcement/form.vue
+++ b/app/components/announcement/form.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { FormSubmitEvent } from "@nuxt/ui";
+
 const {
   announcementState,
   isMobile,
@@ -19,6 +21,7 @@ const {
   userOptions: FilterOption[];
   hostelOptions: FilterOption[];
   roomOptions: FilterOption[];
+  createAnnouncement: (payload: FormSubmitEvent<CreateAnnouncementSchema>) => Promise<void>;
 }>();
 
 const announcementFormState = computed(() => announcementState);
@@ -39,7 +42,7 @@ defineExpose({
     ref="formRef"
     :state="announcementFormState"
     :schema="createAnnouncementSchema"
-    @submit.prevent="console.log($event.data)"
+    @submit.prevent="createAnnouncement"
   >
     <UFormField
       required
@@ -142,22 +145,6 @@ defineExpose({
         placeholder="Search for a room..."
         searchable
         value-key="value"
-        class="w-full"
-      />
-    </UFormField>
-
-    <UFormField
-      required
-      label="Content"
-      name="content"
-      class="mb-4 px-4 w-full"
-    >
-      <UTextarea
-        v-model="announcementFormState.content"
-        required
-        autoresize
-        placeholder="Compose Announcement Content..."
-        :rows="4"
         class="w-full"
       />
     </UFormField>

--- a/app/components/announcement/list.vue
+++ b/app/components/announcement/list.vue
@@ -87,9 +87,11 @@ defineShortcuts({
           from {{ announcement.postedByAdmin.user.name }}
         </p>
 
-        <p class="text-dimmed line-clamp-1">
-          {{ announcement.content }}
-        </p>
+        <div
+          v-if="announcement.content"
+          class="text-dimmed line-clamp-1"
+          v-html="announcement.content"
+        />
       </div>
     </div>
   </div>

--- a/app/components/app/footer.vue
+++ b/app/components/app/footer.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import type { NavigationMenuItem } from "@nuxt/ui";
+
+const items: NavigationMenuItem[] = [
+  {
+    label: "Home",
+    to: { name: "index" },
+  },
+  {
+    label: "About",
+    to: { name: "about" },
+  },
+  {
+    label: "Contact",
+    to: { name: "contact" },
+  },
+  {
+    label: "FAQ",
+    to: { name: "faq" },
+  },
+];
+</script>
+
+<template>
+  <UFooter>
+    <template #left>
+      <p class="text-muted text-sm">
+        Developed by Bright Amoah, Copyright © {{ new Date().getFullYear() }}
+      </p>
+    </template>
+
+    <UNavigationMenu
+      :items="items"
+      variant="link"
+    />
+
+    <template #right>
+      <UButton
+        icon="i-lucide-linkedin"
+        color="neutral"
+        variant="ghost"
+        to="https://www.linkedin.com/in/bright-kweku-amoah-59767a249"
+        target="_blank"
+        aria-label="Discord"
+      />
+
+      <UButton
+        icon="i-lucide-mail"
+        color="neutral"
+        variant="ghost"
+        to="mailto:kingshostelmgt@gmail.com"
+        aria-label="Email"
+      />
+
+      <UButton
+        icon="i-lucide-github"
+        color="neutral"
+        variant="ghost"
+        to="https://github.com/brightamoah/hostel-app"
+        target="_blank"
+        aria-label="GitHub"
+      />
+    </template>
+  </UFooter>
+</template>

--- a/app/components/app/navbar.vue
+++ b/app/components/app/navbar.vue
@@ -31,11 +31,7 @@ const items = ref<NavItem[]>([
     to: { name: "faq" },
     icon: "i-lucide-help-circle",
   },
-  {
-    label: "Signup",
-    to: { name: "auth-signup" },
-    icon: "i-lucide-log-out",
-  },
+
 ]);
 
 const { y } = useWindowScroll();

--- a/app/components/tiptap/editorMain.vue
+++ b/app/components/tiptap/editorMain.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { useDebounceFn, useStorage } from "@vueuse/core";
-
 import { TiptapExtensions } from "./extensions";
 
 const announcementStore = useAnnouncementStore();
@@ -12,7 +10,7 @@ const editor = useEditor({
   editorProps: {
     attributes: {
       class:
-        "bg-muted dark:prose-invert p-5 rounded-b-xl focus:outline-none w-full max-w-full min-h-80 max-h-160 overflow-y-auto prose-headings:font-newsreader font-normal text-default sm:prose-base prose prose-sm prose-neutral",
+        "bg-muted dark:prose-invert p-5 rounded-b-xl focus:outline-none w-full max-w-full min-h-60 max-h-160 overflow-y-auto prose-headings:font-newsreader font-normal text-default sm:prose-base prose prose-sm prose-neutral",
     },
   },
 
@@ -27,13 +25,15 @@ const mainButtonGroup = computed(() => tiptapButtonGroup.value.filter(group => g
 const actionButtonGroup = computed(() => tiptapButtonGroup.value.find(group => group.name === "actions")!);
 
 const charCount = computed(() => editor.value?.storage.characterCount.characters() || 0);
+
 const charLimit = 5000;
 
-// const debouncedUpdate = useDebounceFn(({editor}) => {
-//   const html = editor.getHTML();
-//   content.value = html;
-
-// }, 750);
+const characterStatus = computed(() => {
+  const percent = (charCount.value / charLimit) * 100;
+  if (percent >= 100) return "error";
+  if (percent >= 90) return "warning";
+  return "normal";
+});
 
 onBeforeUnmount(() => {
   unref(editor)?.destroy();
@@ -133,11 +133,23 @@ onBeforeUnmount(() => {
 
     <TiptapEditorContent :editor />
 
-    <div
-      class="flex justify-end px-4 py-2 text-xs"
-      :class="charCount > charLimit * 0.9 ? 'text-error' : 'text-muted'"
-    >
-      {{ charCount }} / {{ charLimit }}
+    <div class="px-3 py-2 w-50">
+      <div class="flex justify-between items-center">
+        <UProgress
+          v-model="charCount"
+          :max="charLimit"
+          :size="isMobile ? 'sm' : 'md'"
+          :color="charCountMap[characterStatus].progress"
+          class="flex-1"
+        />
+
+        <p
+          class="ml-3 text-xs whitespace-nowrap"
+          :class="`text-${charCountMap[characterStatus].description}`"
+        >
+          {{ charCount }} / {{ charLimit }}
+        </p>
+      </div>
     </div>
   </div>
 </template>

--- a/app/error.vue
+++ b/app/error.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import type { NuxtError } from "#app";
+
+import colors from "tailwindcss/colors";
+
+const { error } = defineProps<{ error: NuxtError }>();
+
+const appConfig = useAppConfig();
+const colorMode = useColorMode();
+
+const color = computed(() => colorMode.value === "dark" ? (colors as any)[appConfig.ui.colors.neutral][900] : "white");
+const radius = computed(() => `:root { --ui-radius: ${appConfig.theme.radius}rem; }`);
+const blackAsPrimary = computed(() => appConfig.theme.blackAsPrimary ? `:root { --ui-primary: black; } .dark { --ui-primary: white; }` : ":root {}");
+
+useHead({
+  meta: [
+    { name: "viewport", content: "width=device-width, initial-scale=1" },
+    { key: "theme-color", name: "theme-color", content: color },
+  ],
+  link: [
+    // { rel: 'icon', type: 'image/svg+xml', href: '/icon.svg' }
+  ],
+  style: [
+    { innerHTML: radius, id: "nuxt-ui-radius", tagPriority: -2 },
+    { innerHTML: blackAsPrimary, id: "nuxt-ui-black-as-primary", tagPriority: -2 },
+  ],
+  htmlAttrs: {
+    lang: "en",
+  },
+});
+
+useSeoMeta({
+  titleTemplate: "%s - Kings Hostel Management",
+  title: String(error.statusCode),
+});
+
+useServerSeoMeta({
+  ogSiteName: "Kings Hostel Management",
+  twitterCard: "summary_large_image",
+});
+</script>
+
+<template>
+  <UApp :toaster="{ position: 'bottom-right', duration: 5000 }">
+    <NuxtRouteAnnouncer />
+
+    <NuxtLoadingIndicator
+      color="var(--ui-primary)"
+      :height="2"
+    />
+
+    <AppNavbar />
+
+    <UError :error="error" />
+
+    <AppFooter />
+  </UApp>
+</template>
+
+<style scoped>
+
+</style>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -16,6 +16,8 @@ await refreshSession();
     </UMain>
 
     <AppStarsEffect />
+
+    <AppFooter />
   </UContainer>
 </template>
 

--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -7,10 +7,6 @@ const roleRoutes = useRoleBasedRoute();
 
 <template>
   <div>
-    <!-- <VisitorDetails :visitor="sampleVisitor" /> -->
-
-    <TiptapEditorMain />
-
     <ULink
       :to="roleRoutes?.profile"
       label="Go to home"

--- a/app/pages/admin/announcements.vue
+++ b/app/pages/admin/announcements.vue
@@ -52,8 +52,8 @@ const { isMobile } = storeToRefs(announcementStore);
     <UDashboardPanel
       id="announcements"
       resizable
-      :default-size="25"
-      :min-size="20"
+      :default-size="30"
+      :min-size="30"
       :max-size="30"
       :ui="{
         body: 'p-2 sm:p-0',

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -59,6 +59,8 @@ const features = ref([
     description: "Round-the-clock customer support whenever you need help.",
   },
 ]);
+
+const appConfig = useAppConfig();
 </script>
 
 <template>
@@ -80,7 +82,7 @@ const features = ref([
 
         <AppStarBg
           :star-count="1500"
-          color="rgb(168, 85, 247)"
+          :color="appConfig.ui.colors.primary"
           :size="{ min: 1, max: 6 }"
         />
       </template>

--- a/app/utils/itemMaps.ts
+++ b/app/utils/itemMaps.ts
@@ -50,3 +50,25 @@ export const complaintStatusColorMap: Record<Complaint["status"], ColorType> = {
   "resolved": "success",
   "rejected": "error",
 };
+
+type CharStatus = "normal" | "warning" | "error";
+
+interface CharCountInfo {
+  description: ColorType | "muted";
+  progress: ColorType;
+}
+
+export const charCountMap: Record<CharStatus, CharCountInfo> = {
+  normal: {
+    description: "muted",
+    progress: "success",
+  },
+  warning: {
+    description: "warning",
+    progress: "warning",
+  },
+  error: {
+    description: "error",
+    progress: "error",
+  },
+};

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "nuxt": "4.2.1",
     "nuxt-auth-utils": "0.5.24",
     "nuxt-tiptap-editor": "3.0.0",
+    "sanitize-html": "^2.17.0",
     "vue": "^3.5.25",
     "vue-router": "^4.6.3",
     "zod": "^4.1.13"
@@ -47,6 +48,7 @@
     "@tiptap/extension-text-style": "^3.12.0",
     "@tiptap/extension-underline": "^3.12.0",
     "@types/node": "^24.10.1",
+    "@types/sanitize-html": "^2.16.0",
     "drizzle-kit": "^0.31.7",
     "eslint": "^9.39.1",
     "nodemailer": "^7.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       nuxt-tiptap-editor:
         specifier: 3.0.0
         version: 3.0.0(@floating-ui/dom@1.7.4)(@tiptap/core@3.12.0(@tiptap/pm@3.12.0))(@tiptap/extension-code-block@3.12.0(@tiptap/core@3.12.0(@tiptap/pm@3.12.0))(@tiptap/pm@3.12.0))(highlight.js@11.11.1)(vue@3.5.25(typescript@5.9.3))
+      sanitize-html:
+        specifier: ^2.17.0
+        version: 2.17.0
       vue:
         specifier: ^3.5.25
         version: 3.5.25(typescript@5.9.3)
@@ -103,6 +106,9 @@ importers:
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.1
+      '@types/sanitize-html':
+        specifier: ^2.16.0
+        version: 2.16.0
       drizzle-kit:
         specifier: ^0.31.7
         version: 0.31.7
@@ -3079,6 +3085,9 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  '@types/sanitize-html@2.16.0':
+    resolution: {integrity: sha512-l6rX1MUXje5ztPT0cAFtUayXF06DqPhRyfVXareEN5gGCFaP/iwsxIyKODr9XDhfxPpN6vXUFNfo5kZMXCxBtw==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -4737,6 +4746,9 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -4859,6 +4871,10 @@ packages:
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -5609,6 +5625,9 @@ packages:
   parse-path@7.1.0:
     resolution: {integrity: sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==}
 
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
   parse-statements@1.0.11:
     resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
@@ -6185,6 +6204,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-html@2.17.0:
+    resolution: {integrity: sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==}
 
   sax@1.4.3:
     resolution: {integrity: sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==}
@@ -10319,6 +10341,10 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
+  '@types/sanitize-html@2.16.0':
+    dependencies:
+      htmlparser2: 8.0.2
+
   '@types/unist@3.0.3': {}
 
   '@types/web-bluetooth@0.0.20': {}
@@ -12104,6 +12130,13 @@ snapshots:
 
   hookable@5.5.3: {}
 
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -12250,6 +12283,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-path-inside@4.0.0: {}
+
+  is-plain-object@5.0.0: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -13410,6 +13445,8 @@ snapshots:
     dependencies:
       protocols: 2.0.2
 
+  parse-srcset@1.0.2: {}
+
   parse-statements@1.0.11: {}
 
   parse-url@9.2.0:
@@ -14012,6 +14049,15 @@ snapshots:
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
+
+  sanitize-html@2.17.0:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 8.0.2
+      is-plain-object: 5.0.0
+      parse-srcset: 1.0.2
+      postcss: 8.5.6
 
   sax@1.4.3: {}
 

--- a/server/api/announcement/create.post.ts
+++ b/server/api/announcement/create.post.ts
@@ -1,0 +1,61 @@
+import { announcementQueries } from "~~/server/db/queries";
+import sanitizeHtml from "sanitize-html";
+
+export default defineEventHandler(async (event) => {
+  const { adminData } = await adminSessionCheck(event);
+
+  try {
+    const body = await readValidatedBody(event, body => createAnnouncementSchema.safeParse(body));
+
+    if (!body.success) {
+      throw createError({
+        statusCode: 400,
+        message: `${body.error.issues
+          .map(i => i.message)
+          .join(", ")}`,
+      });
+    }
+
+    const { createAnnouncement } = await announcementQueries();
+
+    const { content, priority, targetAudience, title, targetHostelId, targetRoomId, targetUserId } = body.data;
+
+    const cleanContent = sanitizeHtml(content, {
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
+      allowedAttributes: {
+        ...sanitizeHtml.defaults.allowedAttributes,
+        "img": ["src", "srcset", "alt", "title", "width", "height", "loading"],
+        "*": ["style", "class"],
+      },
+    });
+
+    if (priority === "" || targetAudience === "") {
+      throw createError({
+        statusCode: 400,
+        message: "Priority and Target Audience cannot be empty.",
+      });
+    }
+
+    const newAnnouncement = await createAnnouncement({
+      content: cleanContent,
+      priority,
+      targetAudience,
+      title,
+      targetHostelId,
+      targetRoomId,
+      targetUserId,
+      postedBy: adminData.id,
+    });
+
+    return {
+      success: true,
+      message: "Announcement created successfully. Your announcement has been posted and will be visible to the target audience shortly.",
+      data: newAnnouncement,
+    };
+  }
+  catch (error) {
+    if (error && typeof error === "object" && "statusCode" in error) throw error;
+
+    handleError(error, "Create New Announcement", event);
+  }
+});

--- a/server/api/announcement/draft.ts
+++ b/server/api/announcement/draft.ts
@@ -1,14 +1,14 @@
 export default defineEventHandler(async (event) => {
-  const { user } = await getUserSession(event);
-
-  if (!user) throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+  const { user } = await requireUserSession(event, {
+    message: "Unauthorized, please log in to access announcement drafts.",
+  });
 
   const kv = hubKV();
 
   const KEY = `announcement-draft-${user.id}`;
 
   if (event.method === "GET") {
-    const draft = await kv.get<CreateAnnouncementSchema>(KEY);
+    const draft = await kv.get(KEY);
     return draft || null;
   }
 

--- a/server/api/announcement/getAnnouncementData.get.ts
+++ b/server/api/announcement/getAnnouncementData.get.ts
@@ -21,6 +21,12 @@ export default defineEventHandler(async (event) => {
 
     const announcements = await getAllAnnouncementsForAdmin(adminMakingRequest);
 
+    if (!announcements?.length) return [];
+
+    for (let i = 0; i < announcements.length; i++) {
+      announcements[i].content = sanitizeHtmlContent(announcements[i].content);
+    }
+
     return {
       announcements,
     };

--- a/server/utils/sanitizeHtmlContent.ts
+++ b/server/utils/sanitizeHtmlContent.ts
@@ -1,0 +1,12 @@
+import sanitizeHtml from "sanitize-html";
+
+export function sanitizeHtmlContent(content: string) {
+  return sanitizeHtml(content, {
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
+    allowedAttributes: {
+      ...sanitizeHtml.defaults.allowedAttributes,
+      "img": ["src", "srcset", "alt", "title", "width", "height", "loading"],
+      "*": ["style", "class"],
+    },
+  });
+}


### PR DESCRIPTION
- Change primary color from rose to cyan in app config
- Add theme configuration with radius and blackAsPrimary settings
- Update NuxtLoadingIndicator to use primary color and set height
- Adjust CSS styles, including paragraph margins, selection background, and keyframes positioning
- Modify announcement component default and min sizes to 30
- Use app config for star background color in index page
- Refactor announcement store with toast integration, user session, and improved form validation logic