### PR TITLE
Add Neon PostgreSQL to README tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hostel Management App
 
-A Nuxt 4 application for managing hostel operations, built with TypeScript, Drizzle ORM, and Nuxt UI.
+A Nuxt 4 application for managing hostel operations, built with TypeScript, Drizzle ORM, Neon PostgreSQL, and Nuxt UI.
 
 ## Setup
 


### PR DESCRIPTION
Updated README to include Neon PostgreSQL in the tech stack.